### PR TITLE
build: reorganize app into src package

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,5 +6,12 @@ This file is ASCII-only for safe encoding across terminals.
 - Windows: double-click `run.bat`
 - macOS/Linux: run `./run.sh` (first time: `chmod +x run.sh`)
 
-## CLI
-- `python codex.py`
+## Source Checkout
+- CLI package entry: `PYTHONPATH=src python -m codex_accmgr`
+- GUI package entry: `PYTHONPATH=src python -m codex_accmgr.gui`
+- Compatibility wrapper: `python codex.py`
+
+## Editable Install
+- `python -m pip install -e .`
+- CLI: `codex-accmgr`
+- GUI: `codex-accmgr-gui`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 简洁、跨平台的 Codex 多账号切换命令行工具。
 
 ### ⚙️ 环境依赖
-- 本工具基于 Python 编写，运行前需确保已安装 **[Python 3.6+](https://www.python.org/downloads/)**。
+- 本工具基于 Python 编写，运行前需确保已安装 **[Python 3.10+](https://www.python.org/downloads/)**。
 - 无第三方依赖库，无需额外执行 `pip install`，下载即用。
+- GUI 入口为可选能力，若需要请安装 `PySide6` 或执行 `python -m pip install -e .[gui]`。
 
 ### ✨ 核心功能
 - **轻量管理**：仅保存 `auth.json`，单账号占用极小。
@@ -42,8 +43,11 @@
    ```
    *(或者在网页端点击 `Code` -> `Download ZIP` 解压)*
 2. **运行工具**：
-   - **Windows**: 双击运行目录下的 `run.bat`，或者在终端执行 `python codex.py`
-   - **macOS / Linux**: 在终端执行 `chmod +x run.sh && ./run.sh`，或者执行 `python3 codex.py`
+   - **Windows**: 双击运行目录下的 `run.bat`，或者在终端执行 `set PYTHONPATH=src && python -m codex_accmgr`
+   - **macOS / Linux**: 在终端执行 `chmod +x run.sh && ./run.sh`，或者执行 `PYTHONPATH=src python3 -m codex_accmgr`
+   - **兼容入口**: `python codex.py`
+   - **可编辑安装**: `python -m pip install -e .` 后可直接使用 `codex-accmgr`
+   - **GUI 入口**: `PYTHONPATH=src python -m codex_accmgr.gui`
 
 ### 📖 使用说明
 
@@ -63,11 +67,15 @@
     └── ...
 
 codex-accmgr/
-├── codex.py                # 主程序 CLI 入口
-├── run.bat / run.sh        # 本地运行脚本
-├── bin/                    # 核心逻辑与业务代码
-├── config/accounts.json    # 账号列表配置
-└── scripts/install.py      # 本地环境别名配置脚本
+├── codex.py                          # 兼容 CLI 薄封装入口
+├── run.bat / run.sh                  # 模块化运行脚本
+├── src/codex_accmgr/                 # 主包目录
+│   ├── domain/                       # 纯业务规则与模型
+│   ├── application/                  # 用例编排
+│   ├── infrastructure/               # 文件/进程/系统适配
+│   └── presentation/                 # CLI / GUI 入口
+├── config/accounts.json              # 账号列表配置
+└── pyproject.toml                    # 包声明与入口脚本
 ```
 
 ### 💻 界面预览
@@ -104,8 +112,9 @@ Current Account / 当前账号:
 A lightweight, cross-platform CLI for managing and switching multiple Codex accounts.
 
 ### ⚙️ Prerequisites
-- This tool is written in Python. You must have **[Python 3.6+](https://www.python.org/downloads/)** installed before running it.
+- This tool is written in Python. You must have **[Python 3.10+](https://www.python.org/downloads/)** installed before running it.
 - No third-party dependencies are required (`pip install` is not needed), just download and run.
+- The GUI entry point is optional. Install `PySide6` or run `python -m pip install -e .[gui]` if you want it.
 
 ### ✨ Core Features
 - **Lightweight**: Only keeps `auth.json` with minimal disk usage.
@@ -138,8 +147,11 @@ If you prefer not to use the automated scripts, you can download the source and 
    ```
    *(Or click `Code` -> `Download ZIP` on the web interface to extract horizontally)*
 2. **Run the tool**:
-   - **Windows**: Double-click `run.bat` in the directory, or run `python codex.py` in your terminal.
-   - **macOS / Linux**: Run `chmod +x run.sh && ./run.sh` in your terminal, or run `python3 codex.py`.
+   - **Windows**: Double-click `run.bat`, or run `set PYTHONPATH=src && python -m codex_accmgr` in your terminal.
+   - **macOS / Linux**: Run `chmod +x run.sh && ./run.sh`, or run `PYTHONPATH=src python3 -m codex_accmgr`.
+   - **Compatibility entry**: `python codex.py`
+   - **Editable install**: run `python -m pip install -e .`, then launch `codex-accmgr`
+   - **GUI entry**: `PYTHONPATH=src python -m codex_accmgr.gui`
 
 ### 📖 Usage
 
@@ -161,11 +173,15 @@ If you prefer not to use the automated scripts, you can download the source and 
     └── ...
 
 codex-accmgr/
-├── codex.py                # Main CLI entry point
-├── run.bat / run.sh        # One-click runners
-├── bin/                    # Core logic and business code
-├── config/accounts.json    # Account list configuration
-└── scripts/install.py      # Alias install script
+├── codex.py                          # Compatibility CLI shim
+├── run.bat / run.sh                  # Module-based runners
+├── src/codex_accmgr/                 # Main package
+│   ├── domain/                       # Pure business rules and models
+│   ├── application/                  # Use-case orchestration
+│   ├── infrastructure/               # Files, processes, and system adapters
+│   └── presentation/                 # CLI / GUI entry points
+├── config/accounts.json              # Account list configuration
+└── pyproject.toml                    # Package metadata and entry points
 ```
 
 ### 💻 UI Preview

--- a/codex.py
+++ b/codex.py
@@ -1,176 +1,21 @@
+from __future__ import annotations
+
 import sys
-import os
 from pathlib import Path
-from bin.service import CodexService
-from scripts.install import install
 
-USE_COLOR = sys.stdout.isatty() and os.getenv("NO_COLOR") is None
-APP_NAME = "Codex AccMgr"
-APP_ALIAS = "codex-accmgr"
-APP_VERSION = "v1.1.0"
-SUBTITLE = "account manager"
-BANNER_WIDTH = 50
 
-def _enable_ansi():
-    if os.name == "nt":
-        try:
-            os.system("")
-        except Exception:
-            pass
+def _bootstrap_src_path() -> None:
+    src_dir = Path(__file__).resolve().parent / "src"
+    if src_dir.exists():
+        sys.path.insert(0, str(src_dir))
 
-def _style(text, *codes):
-    if not USE_COLOR or not codes:
-        return text
-    return "\033[" + ";".join(codes) + "m" + text + "\033[0m"
 
-def _banner():
-    line = "+" + "-" * BANNER_WIDTH + "+"
-    print(_style(line, "36"))
-    print(_style(f"| {APP_NAME}{APP_VERSION:>{48 - len(APP_NAME)}} |", "36", "1"))
-    print(_style(f"| {SUBTITLE:<48} |", "36"))
-    print(_style(line, "36"))
+def main(argv: list[str] | None = None) -> int:
+    _bootstrap_src_path()
+    from codex_accmgr.__main__ import main as package_main
 
-def _section(title):
-    print(_style(title, "36", "1"))
-    print(_style("-" * BANNER_WIDTH, "2"))
+    return package_main(argv)
 
-def _mask_email(email):
-    if not email or "@" not in email:
-        return email
-    local, domain = email.split("@", 1)
-    if len(local) <= 2:
-        masked = local[0] + "**" if local else "**"
-    else:
-        masked = local[:3] + "**"
-    return masked + "@" + domain
-
-def check_installation():
-    profile = Path.home() / ".zshrc" if os.name != 'nt' else Path.home() / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
-    if profile.exists():
-        with open(profile, 'r') as f:
-            if APP_ALIAS in f.read():
-                return True
-    return False
-
-def interactive_menu():
-    _enable_ansi()
-    if not check_installation():
-        print(f"{APP_NAME} is not installed in your shell profile. / {APP_NAME} 未在您的 Shell 配置文件中安装。")
-        choice = input("Do you want to install it now? (y/n) / 是否现在安装？(y/n): ")
-        if choice.lower() == 'y':
-            install()
-            return
-
-    service = CodexService()
-    while True:
-        # 获取当前账号详细信息
-        current_info = service.get_current_account_info()
-        usage = service.get_usage_stats()
-        
-        print("")
-        _banner()
-        print(f"\n{'='*50}")
-        print("Current Account / 当前账号:")
-        print(" Alias / 别名 |  Email / 邮箱            |  Plan / 订阅 | Usage / 额度")
-        print(
-            f" {current_info['alias']:<12} |  "
-            f"{_mask_email(current_info['email']):<23} |  "
-            f"{current_info['plan']:<12}| "
-            f"{usage}"
-        )
-        print(f"{'='*50}")
-        print("")
-        print("[1] 查看账号 / List Accounts")
-        print("[2] 添加账号 / Add Account")
-        print("[3] 删除账号 / Remove Account")
-        print("[4] 切换账号 / Switch Account")
-        print("[q] 退出程序 / Exit")
-        print("")
-        
-        choice = input("Select an option / 请选择操作: ")
-        
-        if choice == '1':
-            accounts = service.get_accounts()
-            if not accounts:
-                print("No accounts found / 未找到账号")
-            else:
-                _section("Account List")
-                print(f"\n{'='*60}")
-                print(f"{'Alias/别名':<15} {'Email/邮箱':<30} {'Plan/订阅':<10}")
-                print(f"{'-'*60}")
-                for alias, data in accounts.items():
-                    email = data.get('email', 'Unknown')
-                    plan = data.get('plan', 'Unknown')
-                    # 标记当前账号
-                    marker = " *" if email.lower() == current_info['email'].lower() else ""
-                    print(f"{alias:<15} {email:<30} {plan:<10}{marker}")
-                print(f"{'='*60}")
-                print("* = Current account / * = 当前账号")
-        elif choice == '2':
-            alias = input("Enter alias for new account (q to cancel) / 输入新账号别名(q 取消): ")
-            if alias.strip().lower() == "q":
-                print("Canceled. / 已取消。")
-                continue
-            service.add_account(alias)
-        elif choice == '3':
-            accounts = service.get_accounts()
-            if not accounts:
-                print("No accounts found / 未找到账号")
-                continue
-            
-            _section("Remove Account")
-            print("\nSelect account to remove / 选择要删除的账号:")
-            aliases = list(accounts.keys())
-            for i, alias in enumerate(aliases):
-                email = accounts[alias].get('email', 'Unknown')
-                plan = accounts[alias].get('plan', 'Unknown')
-                print(f"  {i+1}. {alias} ({email} - {plan})")
-            print("  q. Cancel / 取消")
-            
-            idx = input("Select index / 选择序号: ")
-            if idx.strip().lower() == 'q':
-                print("Canceled. / 已取消。")
-                continue
-            if idx.isdigit() and 1 <= int(idx) <= len(aliases):
-                service.remove_account(aliases[int(idx)-1])
-            else:
-                print("Invalid choice / 无效选择")
-        elif choice == '4':
-            accounts = service.get_accounts()
-            
-            _section("Switch Account")
-            print("\nSelect account to switch / 选择要切换的账号:")
-            print("  0. Default (Clean) / 默认 (干净环境)")
-            aliases = list(accounts.keys())
-            for i, alias in enumerate(aliases):
-                email = accounts[alias].get('email', 'Unknown')
-                plan = accounts[alias].get('plan', 'Unknown')
-                print(f"  {i+1}. {alias} ({email} - {plan})")
-            print("  q. Cancel / 取消")
-            
-            idx = input("Select index / 选择序号: ")
-            if idx == '0':
-                auth_file = Path.home() / ".codex" / "auth.json"
-                if auth_file.exists():
-                    auth_file.unlink()
-                print("Switched to Default (Clean) environment. / 已切换到默认 (干净) 环境。")
-                service.refresh_codex_app()
-                print("You can now login with a new account. / 您现在可以登录新账号。")
-            elif idx.strip().lower() == 'q':
-                print("Canceled. / 已取消。")
-                continue
-            elif idx.isdigit() and 1 <= int(idx) <= len(aliases):
-                service.switch_account(aliases[int(idx)-1])
-            else:
-                print("Invalid choice / 无效选择")
-        elif choice.strip().lower() == 'q':
-            print("Goodbye / 再见")
-            break
-        else:
-            print("Invalid choice / 无效选择")
-
-def main():
-    interactive_menu()
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codex-accmgr"
+version = "1.1.0"
+description = "A lightweight CLI and GUI launcher for managing multiple Codex accounts."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "lsjlovezz9-afk" }]
+
+[project.optional-dependencies]
+gui = ["PySide6>=6.6"]
+
+[project.scripts]
+codex-accmgr = "codex_accmgr.__main__:main"
+
+[project.gui-scripts]
+codex-accmgr-gui = "codex_accmgr.gui:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/run.bat
+++ b/run.bat
@@ -1,16 +1,17 @@
 @echo off
 setlocal
 cd /d %~dp0
+set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
 
 where py >nul 2>nul
 if %errorlevel%==0 (
-  py -3 codex.py %*
+  py -3 -m codex_accmgr %*
   exit /b %errorlevel%
 )
 
 where python >nul 2>nul
 if %errorlevel%==0 (
-  python codex.py %*
+  python -m codex_accmgr %*
   exit /b %errorlevel%
 )
 

--- a/run.sh
+++ b/run.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
+export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 
 if command -v python3 >/dev/null 2>&1; then
-  python3 codex.py "$@"
+  python3 -m codex_accmgr "$@"
 elif command -v python >/dev/null 2>&1; then
-  python codex.py "$@"
+  python -m codex_accmgr "$@"
 else
   echo "Python 3 not found. Please install Python 3.10+ and retry."
   exit 1

--- a/src/codex_accmgr/__init__.py
+++ b/src/codex_accmgr/__init__.py
@@ -1,0 +1,7 @@
+"""Codex AccMgr package."""
+
+from .constants import APP_VERSION
+
+__all__ = ["APP_VERSION", "__version__"]
+
+__version__ = APP_VERSION.lstrip("v")

--- a/src/codex_accmgr/__main__.py
+++ b/src/codex_accmgr/__main__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .presentation.cli import main as cli_main
+
+
+def main(argv: list[str] | None = None) -> int:
+    return cli_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_accmgr/application/__init__.py
+++ b/src/codex_accmgr/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application services and use cases."""

--- a/src/codex_accmgr/application/services.py
+++ b/src/codex_accmgr/application/services.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import time
+
+from ..domain.errors import AccountNotFoundError
+from ..domain.models import ClearAuthResult, CurrentAccountInfo, SavedAccount, SwitchResult
+
+
+class AccountApplicationService:
+    def __init__(self, storage, usage_reader, desktop, installer):
+        self.storage = storage
+        self.usage_reader = usage_reader
+        self.desktop = desktop
+        self.installer = installer
+
+    def is_shell_installed(self) -> bool:
+        return self.installer.is_installed()
+
+    def install_shell_alias(self) -> str:
+        return self.installer.install()
+
+    def list_accounts(self) -> list[SavedAccount]:
+        return sorted(self.storage.load_accounts().values(), key=lambda account: account.alias.lower())
+
+    def get_usage_summary(self) -> str:
+        return self.usage_reader.read_latest_usage()
+
+    def get_current_account_info(self) -> CurrentAccountInfo:
+        email, plan = self.storage.read_current_identity()
+        if not email:
+            return CurrentAccountInfo(
+                alias="Not logged in / 未登录",
+                email="N/A",
+                plan="N/A",
+            )
+
+        for account in self.list_accounts():
+            if account.email.lower() == email.lower():
+                return CurrentAccountInfo(
+                    alias=account.alias,
+                    email=email,
+                    plan=plan or account.plan or "Unknown",
+                )
+
+        alias = f"Unknown ({email.split('@', 1)[0]})"
+        return CurrentAccountInfo(alias=alias, email=email, plan=plan or "Unknown")
+
+    def add_current_account(self, alias: str) -> SavedAccount:
+        return self.storage.store_current_account(alias)
+
+    def remove_account(self, alias: str) -> SavedAccount:
+        return self.storage.remove_saved_account(alias)
+
+    def switch_account(self, alias_or_fragment: str) -> SwitchResult:
+        account = self.storage.restore_saved_account(alias_or_fragment)
+        refresh_message = self.desktop.refresh_after_auth_write(self.storage.auth_file)
+        time.sleep(1.5)
+
+        current_email, _ = self.storage.read_current_identity()
+        warning = None
+        if current_email and current_email.lower() != account.email.lower():
+            warning = (
+                "Detected auth.json was overwritten by desktop cache. "
+                "Please close and reopen Codex desktop, then retry."
+            )
+
+        return SwitchResult(
+            alias=account.alias,
+            email=account.email,
+            plan=account.plan,
+            refresh_message=refresh_message,
+            persistence_warning=warning,
+        )
+
+    def clear_current_auth(self) -> ClearAuthResult:
+        self.storage.clear_current_auth()
+        refresh_message = self.desktop.refresh_codex_app()
+        return ClearAuthResult(refresh_message=refresh_message)
+
+    def get_account(self, alias: str) -> SavedAccount:
+        for account in self.list_accounts():
+            if account.alias == alias:
+                return account
+        raise AccountNotFoundError(f"Account '{alias}' not found.")

--- a/src/codex_accmgr/bootstrap.py
+++ b/src/codex_accmgr/bootstrap.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .application.services import AccountApplicationService
+from .infrastructure.accounts import AccountStorage
+from .infrastructure.desktop import DesktopRefresher
+from .infrastructure.paths import AppPaths
+from .infrastructure.shell import ShellProfileInstaller
+from .infrastructure.usage import SessionUsageReader
+
+
+def build_account_service() -> AccountApplicationService:
+    paths = AppPaths.default()
+    return AccountApplicationService(
+        storage=AccountStorage(paths),
+        usage_reader=SessionUsageReader(paths.sessions_dir),
+        desktop=DesktopRefresher(paths),
+        installer=ShellProfileInstaller(paths.project_root),
+    )

--- a/src/codex_accmgr/constants.py
+++ b/src/codex_accmgr/constants.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+APP_NAME = "Codex AccMgr"
+APP_ALIAS = "codex-accmgr"
+APP_GUI_ALIAS = "codex-accmgr-gui"
+APP_VERSION = "v1.1.0"
+SUBTITLE = "account manager"
+BANNER_WIDTH = 50
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG_PATH = PROJECT_ROOT / "config" / "accounts.json"

--- a/src/codex_accmgr/domain/__init__.py
+++ b/src/codex_accmgr/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models and pure helpers."""

--- a/src/codex_accmgr/domain/auth.py
+++ b/src/codex_accmgr/domain/auth.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import base64
+import json
+
+
+def _decode_jwt_payload(jwt_token: str) -> dict:
+    parts = jwt_token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * ((4 - len(payload) % 4) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload + padding)
+        return json.loads(decoded)
+    except Exception:
+        return {}
+
+
+def parse_jwt_email(jwt_token: str) -> str:
+    payload = _decode_jwt_payload(jwt_token)
+    return payload.get("email", "")
+
+
+def parse_jwt_plan(jwt_token: str) -> str:
+    payload = _decode_jwt_payload(jwt_token)
+    auth_data = payload.get("https://api.openai.com/auth", {})
+    if isinstance(auth_data, dict):
+        return auth_data.get("chatgpt_plan_type", "unknown")
+    return "unknown"
+
+
+def mask_email(email: str) -> str:
+    if not email or "@" not in email:
+        return email
+    local, domain = email.split("@", 1)
+    if len(local) <= 2:
+        masked = (local[:1] or "") + "**"
+    else:
+        masked = local[:3] + "**"
+    return masked + "@" + domain

--- a/src/codex_accmgr/domain/errors.py
+++ b/src/codex_accmgr/domain/errors.py
@@ -1,0 +1,22 @@
+class CodexAccMgrError(Exception):
+    """Base application error."""
+
+
+class AliasAlreadyExistsError(CodexAccMgrError):
+    pass
+
+
+class AuthStateNotFoundError(CodexAccMgrError):
+    pass
+
+
+class AuthStateInvalidError(CodexAccMgrError):
+    pass
+
+
+class AccountNotFoundError(CodexAccMgrError):
+    pass
+
+
+class OptionalDependencyError(CodexAccMgrError):
+    pass

--- a/src/codex_accmgr/domain/models.py
+++ b/src/codex_accmgr/domain/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SavedAccount:
+    alias: str
+    email: str
+    plan: str
+
+
+@dataclass(frozen=True)
+class CurrentAccountInfo:
+    alias: str
+    email: str
+    plan: str
+
+
+@dataclass(frozen=True)
+class SwitchResult:
+    alias: str
+    email: str
+    plan: str
+    refresh_message: str
+    persistence_warning: str | None = None
+
+
+@dataclass(frozen=True)
+class ClearAuthResult:
+    refresh_message: str

--- a/src/codex_accmgr/gui.py
+++ b/src/codex_accmgr/gui.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .presentation.gui import main as gui_main
+
+
+def main(argv: list[str] | None = None) -> int:
+    return gui_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_accmgr/infrastructure/__init__.py
+++ b/src/codex_accmgr/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters."""

--- a/src/codex_accmgr/infrastructure/accounts.py
+++ b/src/codex_accmgr/infrastructure/accounts.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+
+from ..domain.auth import parse_jwt_email, parse_jwt_plan
+from ..domain.errors import (
+    AccountNotFoundError,
+    AliasAlreadyExistsError,
+    AuthStateInvalidError,
+    AuthStateNotFoundError,
+)
+from ..domain.models import SavedAccount
+
+
+class AccountStorage:
+    def __init__(self, paths):
+        self.paths = paths
+        self.paths.config_file.parent.mkdir(parents=True, exist_ok=True)
+        self.paths.accounts_dir.mkdir(parents=True, exist_ok=True)
+        if not self.paths.config_file.exists():
+            self.paths.config_file.write_text("{}", encoding="utf-8")
+
+    @property
+    def auth_file(self):
+        return self.paths.auth_file
+
+    @staticmethod
+    def _remove_readonly(func, path, _excinfo):
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    def load_accounts(self) -> dict[str, SavedAccount]:
+        raw = json.loads(self.paths.config_file.read_text(encoding="utf-8"))
+        accounts: dict[str, SavedAccount] = {}
+        for alias, data in raw.items():
+            accounts[alias] = SavedAccount(
+                alias=alias,
+                email=data.get("email", "Unknown"),
+                plan=data.get("plan", "Unknown"),
+            )
+        return accounts
+
+    def save_accounts(self, accounts: dict[str, SavedAccount]) -> None:
+        payload = {
+            alias: {
+                "alias": account.alias,
+                "email": account.email,
+                "plan": account.plan,
+            }
+            for alias, account in accounts.items()
+        }
+        self.paths.config_file.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=4),
+            encoding="utf-8",
+        )
+
+    def read_current_auth(self) -> dict | None:
+        if not self.paths.auth_file.exists():
+            return None
+        try:
+            return json.loads(self.paths.auth_file.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def read_current_identity(self) -> tuple[str | None, str | None]:
+        auth_data = self.read_current_auth()
+        if not auth_data:
+            return None, None
+        id_token = auth_data.get("tokens", {}).get("id_token", "")
+        if not id_token:
+            return None, None
+        return parse_jwt_email(id_token), parse_jwt_plan(id_token)
+
+    def store_current_account(self, alias: str) -> SavedAccount:
+        accounts = self.load_accounts()
+        if alias in accounts:
+            raise AliasAlreadyExistsError(f"Alias '{alias}' already exists.")
+
+        auth_data = self.read_current_auth()
+        if not auth_data or not self.paths.auth_file.exists():
+            raise AuthStateNotFoundError("No auth.json found. Please login first.")
+
+        id_token = auth_data.get("tokens", {}).get("id_token", "")
+        email = parse_jwt_email(id_token)
+        plan = parse_jwt_plan(id_token)
+        if not email:
+            raise AuthStateInvalidError("Cannot parse email from auth.json.")
+
+        account_dir = self.paths.accounts_dir / alias
+        if account_dir.exists():
+            shutil.rmtree(account_dir, onerror=self._remove_readonly)
+        account_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(self.paths.auth_file, account_dir / "auth.json")
+
+        account = SavedAccount(alias=alias, email=email, plan=plan)
+        accounts[alias] = account
+        self.save_accounts(accounts)
+        return account
+
+    def remove_saved_account(self, alias: str) -> SavedAccount:
+        accounts = self.load_accounts()
+        if alias not in accounts:
+            raise AccountNotFoundError(f"Account '{alias}' not found.")
+
+        account_dir = self.paths.accounts_dir / alias
+        if account_dir.exists():
+            shutil.rmtree(account_dir, onerror=self._remove_readonly)
+
+        account = accounts.pop(alias)
+        self.save_accounts(accounts)
+        return account
+
+    def _match_alias(self, alias_or_fragment: str) -> str | None:
+        accounts = self.load_accounts()
+        lowered = alias_or_fragment.lower()
+        for alias in accounts:
+            if alias.lower() == lowered:
+                return alias
+        for alias in accounts:
+            if lowered in alias.lower():
+                return alias
+        return None
+
+    def restore_saved_account(self, alias_or_fragment: str) -> SavedAccount:
+        accounts = self.load_accounts()
+        matched_alias = self._match_alias(alias_or_fragment)
+        if not matched_alias:
+            raise AccountNotFoundError(f"No account matched '{alias_or_fragment}'.")
+
+        target_auth = self.paths.accounts_dir / matched_alias / "auth.json"
+        if not target_auth.exists():
+            raise AuthStateNotFoundError(f"No auth.json found for '{matched_alias}'.")
+
+        self.paths.codex_home.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(target_auth, self.paths.auth_file)
+        try:
+            os.utime(self.paths.auth_file, None)
+        except Exception:
+            pass
+        return accounts[matched_alias]
+
+    def clear_current_auth(self) -> None:
+        if self.paths.auth_file.exists():
+            self.paths.auth_file.unlink()

--- a/src/codex_accmgr/infrastructure/desktop.py
+++ b/src/codex_accmgr/infrastructure/desktop.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import signal
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+
+class DesktopRefresher:
+    def __init__(self, paths):
+        self.paths = paths
+
+    def refresh_after_auth_write(self, auth_path: Path, hold_seconds: float = 2.5) -> str:
+        if os.name != "nt":
+            return self.refresh_codex_app()
+
+        self._set_readonly(auth_path, True)
+        message = self.refresh_codex_app()
+        time.sleep(hold_seconds)
+        self._set_readonly(auth_path, False)
+        return message
+
+    def refresh_codex_app(self) -> str:
+        try:
+            if os.name == "nt":
+                self._ensure_shell_snapshot_disabled()
+                self._ensure_pencil_mcp_proxy()
+                if self._restart_codex_desktop():
+                    return "已重启 Codex 桌面端，账号将自动刷新。"
+                pids = self._find_windows_codex_backend_pids()
+                if not pids:
+                    return (
+                        "未检测到 Codex 后台进程，可能未启动或无权限。/"
+                        " No Codex backend process found."
+                    )
+                for pid in pids:
+                    self._stop_windows_process(pid)
+                return (
+                    "已请求 Codex 后台进程重启，账号将自动刷新。/"
+                    " Codex backend restarted for auth refresh."
+                )
+
+            if platform.system() == "Darwin" and self._restart_codex_desktop_macos():
+                return "已重启 Codex 桌面端，账号将自动刷新。"
+
+            pids = self._find_unix_codex_backend_pids()
+            if not pids:
+                return (
+                    "未检测到 Codex 后台进程，可能未启动或无权限。/"
+                    " No Codex backend process found."
+                )
+            for pid in pids:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except Exception:
+                    continue
+            return (
+                "已请求 Codex 后台进程重启，账号将自动刷新。/"
+                " Codex backend restarted for auth refresh."
+            )
+        except Exception:
+            return "自动刷新失败，请手动重启 Codex。/ Auto refresh failed, please restart Codex manually."
+
+    @staticmethod
+    def _set_readonly(path: Path, readonly: bool):
+        try:
+            if readonly:
+                os.chmod(path, stat.S_IREAD)
+            else:
+                os.chmod(path, stat.S_IWRITE | stat.S_IREAD)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _stop_windows_process(pid: int) -> None:
+        for force in ("", " -Force"):
+            try:
+                subprocess.run(
+                    [
+                        "powershell",
+                        "-NoProfile",
+                        "-Command",
+                        f"Stop-Process -Id {pid}{force}",
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                time.sleep(0.8)
+            except Exception:
+                continue
+
+    def _ensure_pencil_mcp_proxy(self) -> bool:
+        if os.name != "nt" or not self.paths.config_toml.exists():
+            return False
+        try:
+            text = self.paths.config_toml.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return False
+        if "[mcp_servers.pencil]" not in text:
+            return False
+
+        lines = text.splitlines(keepends=True)
+        section_re = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+        cmd_re = re.compile(r'^\s*command\s*=\s*"(.*)"\s*$')
+        args_re = re.compile(r'^\s*args\s*=\s*\[(.*)\]\s*$')
+
+        start = None
+        end = None
+        for index, line in enumerate(lines):
+            match = section_re.match(line)
+            if match and match.group(1).strip() == "mcp_servers.pencil":
+                start = index
+                continue
+            if start is not None and match:
+                end = index
+                break
+        if start is None:
+            return False
+        if end is None:
+            end = len(lines)
+
+        cmd_line_idx = None
+        args_line_idx = None
+        cmd_value = None
+        args_value: list[str] = []
+        for index in range(start + 1, end):
+            line = lines[index]
+            match_cmd = cmd_re.match(line)
+            if match_cmd:
+                cmd_line_idx = index
+                cmd_value = match_cmd.group(1)
+                continue
+            match_args = args_re.match(line)
+            if match_args:
+                args_line_idx = index
+                args_value = re.findall(r'"([^"]*)"', match_args.group(1))
+
+        if not cmd_value:
+            return False
+        if cmd_value.endswith("mcp_proxy.py") or any("mcp_proxy.py" in arg for arg in args_value):
+            return True
+
+        proxy_path = (Path(__file__).resolve().parent / "mcp_proxy.py").resolve()
+        new_cmd = "py"
+        new_args = ["-3", str(proxy_path), "--", cmd_value, *args_value]
+
+        def toml_quote(value: str) -> str:
+            return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+        if cmd_line_idx is None or args_line_idx is None:
+            return False
+
+        lines[cmd_line_idx] = f"command = {toml_quote(new_cmd)}\n"
+        lines[args_line_idx] = "args = [ " + ", ".join(toml_quote(arg) for arg in new_args) + " ]\n"
+
+        backup_path = self.paths.accounts_dir / "pencil_mcp_original.json"
+        try:
+            backup_path.write_text(
+                json.dumps({"command": cmd_value, "args": args_value}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            self.paths.config_toml.write_text("".join(lines), encoding="utf-8")
+        except Exception:
+            return False
+        return True
+
+    def _ensure_shell_snapshot_disabled(self) -> bool:
+        if not self.paths.config_toml.exists():
+            return False
+        try:
+            text = self.paths.config_toml.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return False
+
+        line_re = re.compile(r"^\s*shell_snapshot\s*=\s*(true|false)\s*$", re.IGNORECASE | re.MULTILINE)
+        if line_re.search(text):
+            new_text = line_re.sub("shell_snapshot = false", text)
+        else:
+            suffix = "\n" if text.endswith("\n") else "\n\n"
+            new_text = text + f"{suffix}shell_snapshot = false\n"
+
+        if new_text == text:
+            return True
+        try:
+            self.paths.config_toml.write_text(new_text, encoding="utf-8")
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _restart_codex_desktop() -> bool:
+        command = (
+            "$pkg = Get-AppxPackage -Name OpenAI.Codex -ErrorAction SilentlyContinue;"
+            "Get-Process -Name Codex,codex -ErrorAction SilentlyContinue | Stop-Process;"
+            "Start-Sleep -Milliseconds 500;"
+            "Get-Process -Name Codex,codex -ErrorAction SilentlyContinue | Stop-Process -Force;"
+            "if ($pkg) { Start-Process \"shell:AppsFolder\\$($pkg.PackageFamilyName)!App\"; };"
+            "Start-Sleep -Milliseconds 800;"
+            "if (Get-Process -Name Codex -ErrorAction SilentlyContinue) { Write-Output 'OK' }"
+        )
+        try:
+            result = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", command],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            return "OK" in (result.stdout or "")
+        except Exception:
+            return False
+
+    @staticmethod
+    def _restart_codex_desktop_macos() -> bool:
+        try:
+            subprocess.run(
+                ["osascript", "-e", 'quit app "Codex"'],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            time.sleep(0.6)
+            subprocess.run(
+                ["open", "-a", "Codex"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            time.sleep(0.6)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _find_windows_codex_backend_pids() -> list[int]:
+        command = (
+            "$ids = @();"
+            "$procs = Get-Process -Name codex -ErrorAction SilentlyContinue | Where-Object {"
+            "  $p = $_.Path; if (-not $p) { $p = '' };"
+            "  $p -match 'resources\\\\\\\\codex\\.exe' -or $p -match 'app\\\\\\\\asar\\\\\\\\unpacked\\\\\\\\codex'"
+            "};"
+            "if ($procs) { $ids += $procs | Select-Object -ExpandProperty Id };"
+            "if (-not $ids) {"
+            "  try {"
+            "    $cim = Get-CimInstance Win32_Process -Filter \"Name='codex.exe'\" | "
+            "      Select-Object ProcessId,ExecutablePath,CommandLine;"
+            "    foreach ($p in $cim) {"
+            "      $exe = $p.ExecutablePath; if (-not $exe) { $exe = '' };"
+            "      $cmd = $p.CommandLine; if (-not $cmd) { $cmd = '' };"
+            "      $path = $exe + ' ' + $cmd;"
+            "      if ($path -match 'resources\\\\\\\\codex\\.exe' -or $path -match 'app\\.asar\\.unpacked\\\\\\\\codex' -or $cmd -match 'app-server') {"
+            "        $ids += $p.ProcessId"
+            "      }"
+            "    }"
+            "  } catch { }"
+            "};"
+            "if (-not $ids) {"
+            "  try {"
+            "    $fallback = Get-Process -Name codex -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id;"
+            "    if ($fallback) { $ids += $fallback }"
+            "  } catch { }"
+            "};"
+            "$ids | Sort-Object -Unique"
+        )
+        try:
+            result = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", command],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            return []
+        pids: list[int] = []
+        for line in (result.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                pids.append(int(line))
+            except ValueError:
+                continue
+        return pids
+
+    @staticmethod
+    def _find_unix_codex_backend_pids() -> list[int]:
+        try:
+            result = subprocess.run(
+                ["ps", "-ax", "-o", "pid=", "-o", "command="],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            return []
+        pids: list[int] = []
+        for line in (result.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            pid_str, command = parts
+            if "/resources/codex" not in command and "/resources/app.asar.unpacked/codex" not in command:
+                continue
+            if "Codex.app/Contents/MacOS/Codex" in command:
+                continue
+            try:
+                pids.append(int(pid_str))
+            except ValueError:
+                continue
+        return pids

--- a/src/codex_accmgr/infrastructure/mcp_proxy.py
+++ b/src/codex_accmgr/infrastructure/mcp_proxy.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+
+INTERCEPT_METHODS = {
+    "resources/list",
+    "resources/templates",
+}
+
+
+def _read_message(stream):
+    headers = {}
+    while True:
+        line = stream.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        if b":" in line:
+            key, value = line.split(b":", 1)
+            headers[key.strip().lower()] = value.strip()
+    length = headers.get(b"content-length")
+    if not length:
+        return None
+    try:
+        length = int(length)
+    except Exception:
+        return None
+    body = stream.read(length)
+    if not body:
+        return None
+    return body
+
+
+def _write_message(stream, body_bytes):
+    header = f"Content-Length: {len(body_bytes)}\r\n\r\n".encode("utf-8")
+    stream.write(header)
+    stream.write(body_bytes)
+    stream.flush()
+
+
+def _server_to_client(server_stdout, client_stdout):
+    while True:
+        body = _read_message(server_stdout)
+        if body is None:
+            break
+        _write_message(client_stdout, body)
+
+
+def _proxy(server_cmd):
+    server = subprocess.Popen(
+        server_cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+    )
+
+    thread = threading.Thread(
+        target=_server_to_client,
+        args=(server.stdout, sys.stdout.buffer),
+        daemon=True,
+    )
+    thread.start()
+
+    client_in = sys.stdin.buffer
+    server_in = server.stdin
+
+    while True:
+        body = _read_message(client_in)
+        if body is None:
+            break
+        try:
+            msg = json.loads(body.decode("utf-8"))
+        except Exception:
+            _write_message(server_in, body)
+            continue
+
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        if method in INTERCEPT_METHODS and msg_id is not None:
+            result = {"resourceTemplates": []} if method == "resources/templates" else {"resources": []}
+            response = {"jsonrpc": "2.0", "id": msg_id, "result": result}
+            _write_message(sys.stdout.buffer, json.dumps(response).encode("utf-8"))
+            continue
+
+        _write_message(server_in, body)
+
+    try:
+        server.terminate()
+    except Exception:
+        pass
+
+
+def main():
+    args = sys.argv[1:]
+    if args[:1] == ["--"]:
+        args = args[1:]
+    if not args:
+        sys.stderr.write("Usage: mcp_proxy.py -- <server> [args...]\n")
+        raise SystemExit(2)
+    _proxy(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codex_accmgr/infrastructure/paths.py
+++ b/src/codex_accmgr/infrastructure/paths.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..constants import DEFAULT_CONFIG_PATH, PROJECT_ROOT
+
+
+@dataclass(frozen=True)
+class AppPaths:
+    project_root: Path
+    config_file: Path
+    codex_home: Path
+    auth_file: Path
+    accounts_dir: Path
+    sessions_dir: Path
+    config_toml: Path
+
+    @classmethod
+    def default(cls) -> "AppPaths":
+        codex_home = Path.home() / ".codex"
+        return cls(
+            project_root=PROJECT_ROOT,
+            config_file=DEFAULT_CONFIG_PATH,
+            codex_home=codex_home,
+            auth_file=codex_home / "auth.json",
+            accounts_dir=codex_home / "codex-accmgr",
+            sessions_dir=codex_home / "sessions",
+            config_toml=codex_home / "config.toml",
+        )

--- a/src/codex_accmgr/infrastructure/shell.py
+++ b/src/codex_accmgr/infrastructure/shell.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from ..constants import APP_ALIAS, APP_NAME
+
+
+class ShellProfileInstaller:
+    def __init__(self, project_root: Path):
+        self.project_root = project_root
+
+    def profile_path(self) -> Path:
+        if os.name == "nt":
+            profile_dir = Path.home() / "Documents" / "PowerShell"
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            return profile_dir / "Microsoft.PowerShell_profile.ps1"
+        return Path.home() / ".zshrc"
+
+    def is_installed(self) -> bool:
+        profile = self.profile_path()
+        if not profile.exists():
+            return False
+        try:
+            return APP_ALIAS in profile.read_text(encoding="utf-8")
+        except Exception:
+            return False
+
+    def install(self) -> str:
+        profile = self.profile_path()
+        profile.parent.mkdir(parents=True, exist_ok=True)
+        launcher_path = (self.project_root / "codex.py").resolve()
+        python_path = Path(sys.executable).resolve()
+
+        if os.name == "nt":
+            snippet = f"\nfunction {APP_ALIAS} {{ & '{python_path}' '{launcher_path}' $args }}\n"
+        else:
+            snippet = f"\nalias {APP_ALIAS}='\"{python_path}\" \"{launcher_path}\"'\n"
+
+        with open(profile, "a", encoding="utf-8") as handle:
+            handle.write(snippet)
+
+        return (
+            f"{APP_NAME} installed! Please restart your terminal or run "
+            f"'source {profile}'. / {APP_NAME} 安装成功！请重启终端或运行 'source {profile}'。"
+        )

--- a/src/codex_accmgr/infrastructure/usage.py
+++ b/src/codex_accmgr/infrastructure/usage.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+
+
+class SessionUsageReader:
+    def __init__(self, sessions_dir):
+        self.sessions_dir = sessions_dir
+
+    def read_latest_usage(self) -> str:
+        log_files: list[str] = []
+        for root, _dirs, files in os.walk(self.sessions_dir):
+            for name in files:
+                if name.startswith("rollout-") and name.endswith(".jsonl"):
+                    log_files.append(os.path.join(root, name))
+
+        if not log_files:
+            return "N/A"
+
+        log_files.sort(key=os.path.getmtime, reverse=True)
+        latest_file = log_files[0]
+        try:
+            with open(latest_file, "r", encoding="utf-8") as handle:
+                lines = handle.readlines()
+        except Exception:
+            return "Error parsing logs / 日志解析错误"
+
+        for line in reversed(lines):
+            try:
+                data = json.loads(line.strip())
+            except Exception:
+                continue
+            if data.get("type") != "event_msg":
+                continue
+            payload = data.get("payload", {})
+            if payload.get("type") != "token_count":
+                continue
+            return self._format_rate_limits(payload.get("rate_limits", {}))
+
+        return "N/A"
+
+    def _format_rate_limits(self, rate_limits: dict) -> str:
+        limits = []
+        primary = rate_limits.get("primary", {})
+        secondary = rate_limits.get("secondary", {})
+        if primary:
+            limits.append(primary)
+        if secondary:
+            limits.append(secondary)
+        if not limits:
+            return "N/A"
+
+        parts = []
+        for limit in limits:
+            used_percent = limit.get("used_percent", 0) or 0
+            try:
+                used_percent = float(used_percent)
+            except Exception:
+                used_percent = 0.0
+            left_percent = round(max(0.0, 100.0 - used_percent), 1)
+            parts.append(
+                f"{self._label_for_window(limit.get('window_minutes'))}: "
+                f"{left_percent}% left (reset {self._format_reset(limit.get('resets_at'))})"
+            )
+        return " | ".join(parts)
+
+    @staticmethod
+    def _label_for_window(minutes):
+        if minutes is None:
+            return "Unknown"
+        if minutes >= 10080:
+            return "Weekly"
+        if 240 <= minutes <= 360:
+            return "5h"
+        return f"{minutes}m"
+
+    @staticmethod
+    def _format_reset(resets_at):
+        if not isinstance(resets_at, (int, float)):
+            return "unknown"
+        try:
+            return datetime.fromtimestamp(resets_at).strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            return "unknown"

--- a/src/codex_accmgr/presentation/__init__.py
+++ b/src/codex_accmgr/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Presentation layer entry points."""

--- a/src/codex_accmgr/presentation/cli.py
+++ b/src/codex_accmgr/presentation/cli.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from ..bootstrap import build_account_service
+from ..constants import APP_NAME, APP_VERSION, BANNER_WIDTH, SUBTITLE
+from ..domain.auth import mask_email
+from ..domain.errors import CodexAccMgrError
+
+
+class CliApp:
+    def __init__(self, service):
+        self.service = service
+        self.use_color = sys.stdout.isatty() and os.getenv("NO_COLOR") is None
+
+    def run(self, prompt_install: bool = True) -> int:
+        self._enable_ansi()
+        if prompt_install and sys.stdin.isatty() and not self.service.is_shell_installed():
+            print(
+                f"{APP_NAME} is not installed in your shell profile. / "
+                f"{APP_NAME} 未在您的 Shell 配置文件中安装。"
+            )
+            choice = self._read_input("Do you want to install it now? (y/n) / 是否现在安装？(y/n): ")
+            if choice and choice.lower() == "y":
+                print(self.service.install_shell_alias())
+                return 0
+
+        while True:
+            current_info = self.service.get_current_account_info()
+            usage = self.service.get_usage_summary()
+
+            print("")
+            self._banner()
+            print(f"\n{'=' * 50}")
+            print("Current Account / 当前账号:")
+            print(" Alias / 别名 |  Email / 邮箱            |  Plan / 订阅 | Usage / 额度")
+            print(
+                f" {current_info.alias:<12} |  "
+                f"{mask_email(current_info.email):<23} |  "
+                f"{current_info.plan:<12}| "
+                f"{usage}"
+            )
+            print(f"{'=' * 50}")
+            print("")
+            print("[1] 查看账号 / List Accounts")
+            print("[2] 添加账号 / Add Account")
+            print("[3] 删除账号 / Remove Account")
+            print("[4] 切换账号 / Switch Account")
+            print("[q] 退出程序 / Exit")
+            print("")
+
+            choice = self._read_input("Select an option / 请选择操作: ")
+            if choice is None:
+                print("Goodbye / 再见")
+                return 0
+            choice = choice.lower()
+            try:
+                if choice == "1":
+                    self._show_accounts(current_info.email)
+                elif choice == "2":
+                    self._add_account()
+                elif choice == "3":
+                    self._remove_account()
+                elif choice == "4":
+                    self._switch_account()
+                elif choice == "q":
+                    print("Goodbye / 再见")
+                    return 0
+                else:
+                    print("Invalid choice / 无效选择")
+            except CodexAccMgrError as error:
+                print(str(error))
+
+    def _show_accounts(self, current_email: str) -> None:
+        accounts = self.service.list_accounts()
+        if not accounts:
+            print("No accounts found / 未找到账号")
+            return
+        self._section("Account List")
+        print(f"\n{'=' * 60}")
+        print(f"{'Alias/别名':<15} {'Email/邮箱':<30} {'Plan/订阅':<10}")
+        print(f"{'-' * 60}")
+        for account in accounts:
+            marker = ""
+            if current_email != "N/A" and account.email.lower() == current_email.lower():
+                marker = " *"
+            print(f"{account.alias:<15} {account.email:<30} {account.plan:<10}{marker}")
+        print(f"{'=' * 60}")
+        print("* = Current account / * = 当前账号")
+
+    def _add_account(self) -> None:
+        alias = self._read_input("Enter alias for new account (q to cancel) / 输入新账号别名(q 取消): ")
+        if alias is None or alias.lower() == "q":
+            print("Canceled. / 已取消。")
+            return
+        if not alias:
+            print("Alias cannot be empty / 别名不能为空")
+            return
+        account = self.service.add_current_account(alias)
+        print(f"Account '{account.alias}' created. / 账号 '{account.alias}' 已创建。")
+        print(f"  Email: {account.email}")
+        print(f"  Plan: {account.plan}")
+
+    def _remove_account(self) -> None:
+        accounts = self.service.list_accounts()
+        if not accounts:
+            print("No accounts found / 未找到账号")
+            return
+
+        self._section("Remove Account")
+        print("\nSelect account to remove / 选择要删除的账号:")
+        for index, account in enumerate(accounts, start=1):
+            print(f"  {index}. {account.alias} ({account.email} - {account.plan})")
+        print("  q. Cancel / 取消")
+
+        choice = self._read_input("Select index / 选择序号: ")
+        if choice is None or choice.lower() == "q":
+            print("Canceled. / 已取消。")
+            return
+        if not choice.isdigit() or not (1 <= int(choice) <= len(accounts)):
+            print("Invalid choice / 无效选择")
+            return
+
+        account = self.service.remove_account(accounts[int(choice) - 1].alias)
+        print(f"Account '{account.alias}' removed. / 账号 '{account.alias}' 已删除。")
+
+    def _switch_account(self) -> None:
+        accounts = self.service.list_accounts()
+
+        self._section("Switch Account")
+        print("\nSelect account to switch / 选择要切换的账号:")
+        print("  0. Default (Clean) / 默认 (干净环境)")
+        for index, account in enumerate(accounts, start=1):
+            print(f"  {index}. {account.alias} ({account.email} - {account.plan})")
+        print("  q. Cancel / 取消")
+
+        choice = self._read_input("Select index / 选择序号: ")
+        if choice is None:
+            print("Canceled. / 已取消。")
+            return
+        if choice == "0":
+            result = self.service.clear_current_auth()
+            print("Switched to Default (Clean) environment. / 已切换到默认 (干净) 环境。")
+            print(result.refresh_message)
+            print("You can now login with a new account. / 您现在可以登录新账号。")
+            return
+        if choice.lower() == "q":
+            print("Canceled. / 已取消。")
+            return
+        if not choice.isdigit() or not (1 <= int(choice) <= len(accounts)):
+            print("Invalid choice / 无效选择")
+            return
+
+        result = self.service.switch_account(accounts[int(choice) - 1].alias)
+        print(f"Successfully switched to account: {result.alias} / 已成功切换至账号: {result.alias}")
+        print(f"  Email: {result.email}")
+        print(f"  Plan: {result.plan}")
+        print(result.refresh_message)
+        if result.persistence_warning:
+            print(result.persistence_warning)
+
+    def _enable_ansi(self) -> None:
+        if os.name == "nt":
+            try:
+                os.system("")
+            except Exception:
+                pass
+
+    @staticmethod
+    def _read_input(prompt: str) -> str | None:
+        try:
+            return input(prompt).strip()
+        except EOFError:
+            return None
+
+    def _style(self, text: str, *codes: str) -> str:
+        if not self.use_color or not codes:
+            return text
+        return "\033[" + ";".join(codes) + "m" + text + "\033[0m"
+
+    def _banner(self) -> None:
+        line = "+" + "-" * BANNER_WIDTH + "+"
+        print(self._style(line, "36"))
+        print(self._style(f"| {APP_NAME}{APP_VERSION:>{48 - len(APP_NAME)}} |", "36", "1"))
+        print(self._style(f"| {SUBTITLE:<48} |", "36"))
+        print(self._style(line, "36"))
+
+    def _section(self, title: str) -> None:
+        print(self._style(title, "36", "1"))
+        print(self._style("-" * BANNER_WIDTH, "2"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="codex-accmgr",
+        description="Manage multiple Codex auth.json profiles from the CLI.",
+    )
+    parser.add_argument("--version", action="version", version=APP_VERSION)
+    parser.add_argument("--gui", action="store_true", help="Launch the GUI entry point.")
+    parser.add_argument(
+        "--no-install-prompt",
+        action="store_true",
+        help="Skip the shell-profile installation prompt before entering the menu.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.gui:
+        from ..gui import main as gui_main
+
+        return gui_main([])
+    return CliApp(build_account_service()).run(prompt_install=not args.no_install_prompt)

--- a/src/codex_accmgr/presentation/gui.py
+++ b/src/codex_accmgr/presentation/gui.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ..bootstrap import build_account_service
+from ..constants import APP_NAME, APP_VERSION
+from ..domain.auth import mask_email
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="codex-accmgr-gui",
+        description="Launch the Codex AccMgr GUI.",
+    )
+    parser.add_argument("--version", action="version", version=APP_VERSION)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    parser.parse_args(argv)
+
+    try:
+        from PySide6.QtWidgets import (
+            QApplication,
+            QLabel,
+            QListWidget,
+            QPushButton,
+            QVBoxLayout,
+            QWidget,
+        )
+    except ImportError:
+        print(
+            "PySide6 is required for the GUI entry. Install it with "
+            "`pip install .[gui]` or `pip install PySide6`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    service = build_account_service()
+
+    class MainWindow(QWidget):
+        def __init__(self):
+            super().__init__()
+            self.setWindowTitle(f"{APP_NAME} GUI")
+            self.setMinimumWidth(520)
+
+            self.current_label = QLabel()
+            self.accounts_list = QListWidget()
+            self.accounts_list.setAlternatingRowColors(True)
+            hint_label = QLabel("Account mutations stay in the CLI entry for now.")
+            refresh_button = QPushButton("Refresh")
+            refresh_button.clicked.connect(self.refresh_view)
+
+            layout = QVBoxLayout()
+            layout.addWidget(self.current_label)
+            layout.addWidget(self.accounts_list)
+            layout.addWidget(hint_label)
+            layout.addWidget(refresh_button)
+            self.setLayout(layout)
+            self.refresh_view()
+
+        def refresh_view(self):
+            current = service.get_current_account_info()
+            usage = service.get_usage_summary()
+            self.current_label.setText(
+                f"Current: {current.alias}\n"
+                f"Email: {mask_email(current.email)}\n"
+                f"Plan: {current.plan}\n"
+                f"Usage: {usage}"
+            )
+            self.accounts_list.clear()
+            accounts = service.list_accounts()
+            if not accounts:
+                self.accounts_list.addItem("No saved accounts")
+                return
+            for account in accounts:
+                self.accounts_list.addItem(
+                    f"{account.alias} | {mask_email(account.email)} | {account.plan}"
+                )
+
+    app = QApplication([sys.argv[0], *(argv or [])])
+    window = MainWindow()
+    window.show()
+    return app.exec()


### PR DESCRIPTION
﻿## Summary
- reorganize the project into `src/codex_accmgr/` with `domain`, `application`, `infrastructure`, and `presentation` layers
- add a composition root plus explicit CLI and GUI entry points while keeping `codex.py` as a thin compatibility wrapper
- update `run.bat`, `run.sh`, `pyproject.toml`, `README.md`, and `QUICKSTART.md` for the new package-based startup flow

## Acceptance
- [x] `python -m codex_accmgr --help` works from source checkout with `PYTHONPATH=src`
- [x] `python -c "import codex_accmgr"` does not trigger side effects
- [x] `python -m codex_accmgr.gui` returns a clear missing-`PySide6` error in a clean environment
- [x] `python codex.py --help` and `run.bat --help` still work as compatibility entry points

Closes #1
